### PR TITLE
Fix for #2 'Template settings other than 'cache' in init get overridden by doT.templateSettings'

### DIFF
--- a/dot-emc.js
+++ b/dot-emc.js
@@ -175,9 +175,9 @@ doT Express Master of Ceremonies
     if (typeof fn !== "function") {
       fn = (function() {});
     }
-    curOptions = mergeObjects(true, options, defaults.options, {
+    curOptions = mergeObjects(true, options, {
       templateSettings: doT.templateSettings
-    });
+    }, defaults.options);
     def = new Defines();
     try {
       if (html && curOptions.pretty) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dot-emc",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "dot-emc is a doT stub for Express 3.x with support for caching and partials.",
   "main": "dot-emc.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/nerdo/dot-emc.git"
+    "url": "https://github.com/chrisware/dot-emc.git"
   },
   "dependencies": {
     "dot": ">= 1.0.0"

--- a/src/dot-emc.coffee
+++ b/src/dot-emc.coffee
@@ -112,7 +112,7 @@ renderFile = (filename, options, fn) ->
 		fn = options
 		options = {}
 	fn = ( -> ) if typeof fn != "function"
-	curOptions = mergeObjects true, options, defaults.options, templateSettings: doT.templateSettings
+	curOptions = mergeObjects true, options, templateSettings: doT.templateSettings, defaults.options
 	def = new Defines()
 
 	try


### PR DESCRIPTION
Moved `defaults.options` to be the last argument of `mergeObjects`.  Template settings specified in your init function (e.g. `strip`) now override `dot.templateSettings`.  The `cache` setting is preserved as this property does not exist in the default `dot.templateSettings`.
